### PR TITLE
Copilot/exodus auto export next pruning point

### DIFF
--- a/app/component_manager.go
+++ b/app/component_manager.go
@@ -118,6 +118,8 @@ func NewComponentManager(cfg *config.Config, db infrastructuredatabase.Database,
 		PruningInterval:                   pruningInterval,
 		EnableSanityCheckPruningUTXOSet:   cfg.EnableSanityCheckPruningUTXOSet,
 		EnableUTXODebugDiagnostics:        cfg.EnableUTXODebugDiagnostics,
+		EnableAutoExodusExportOnPruning:   cfg.EnableAutoExodusExportOnPruning,
+		AutoExodusExportDir:               cfg.AutoExodusExportDir,
 		UseHoohashCLibrary:                cfg.UseHoohashCLibrary,
 		PastMedianTimeValidationTolerance: cfg.PastMedianTimeValidationTolerance,
 	}

--- a/docs/exodus-pruning-point.md
+++ b/docs/exodus-pruning-point.md
@@ -79,6 +79,23 @@ The node must be stopped before running `htnexodus create`, `htnexodus diff --li
 running node for the same database files. `htnexodus verify` and a `htnexodus diff` between two
 already-generated bundles do not touch a node's database at all and can be run at any time.
 
+### Automatic export at the next pruning-point movement
+
+For operator investigations, start `htnd` with `--enable-auto-exodus-export-on-pruning`. The
+next (and every subsequent) pruning-point movement schedules one best-effort asynchronous bundle
+export using the `acceptance-data` derivation. It is disabled by default and does not alter
+consensus decisions or make pruning fail when an export fails.
+
+Bundles are written under `<AppDir>/exodus-auto-export` by default, in a
+`pruning-point-<daa-score>-<block-hash>` directory. Override the parent directory with
+`--auto-exodus-export-dir=/path/to/exports`.
+
+Look for the `[AUTO-EXODUS] PASS` or `[AUTO-EXODUS] FAIL` line. It records the pruning-point
+hash and DAA score, exported entry count, computed commitment, header commitment, and bundle
+path. `PASS` means that node's acceptance-data export reproduced the pruning-point header
+commitment; `FAIL` leaves the bundle available for `htnexodus diff` but means it must not be
+treated as a candidate without further investigation.
+
 ### Generate a candidate
 
 By block hash:

--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"math/big"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"time"
@@ -18,8 +19,10 @@ import (
 	"github.com/HoosatNetwork/HTND/domain/consensus/utils/consensushashing"
 	"github.com/HoosatNetwork/HTND/domain/consensus/utils/constants"
 	"github.com/HoosatNetwork/HTND/domain/consensus/utils/utxo"
+	"github.com/HoosatNetwork/HTND/domain/exodus"
 	"github.com/HoosatNetwork/HTND/infrastructure/logger"
 	"github.com/HoosatNetwork/HTND/util/staging"
+	"github.com/HoosatNetwork/HTND/version"
 	"github.com/pkg/errors"
 )
 
@@ -75,6 +78,60 @@ type consensus struct {
 
 	consensusEventsChan chan externalapi.ConsensusEvent
 	virtualNotUpdated   bool
+}
+
+func (s *consensus) exportPruningPointExodusBundle(pruningPoint *externalapi.DomainHash, exportRoot, network string) {
+	onEnd := logger.LogAndMeasureExecutionTime(log, "[AUTO-EXODUS] exportPruningPointExodusBundle")
+	defer onEnd()
+
+	header, err := s.GetBlockHeader(pruningPoint)
+	if err != nil {
+		log.Errorf("[AUTO-EXODUS] FAILED: could not fetch header for pruning point %s: %s", pruningPoint, err)
+		return
+	}
+	daaScore := header.DAAScore()
+	bundleDir := filepath.Join(exportRoot, "pruning-point-"+fmt.Sprintf("%d-%s", daaScore, pruningPoint))
+	log.Infof("[AUTO-EXODUS] exporting pruning point %s (DAA score %d) from acceptance data to %s",
+		pruningPoint, daaScore, bundleDir)
+
+	writer, err := exodus.NewWriter(bundleDir, exodus.BundleTarget{
+		BlockHash: pruningPoint,
+		DAAScore:  daaScore,
+	}, exodus.DefaultChunkEntryCount)
+	if err != nil {
+		log.Errorf("[AUTO-EXODUS] FAILED: could not create bundle at %s: %s", bundleDir, err)
+		return
+	}
+
+	err = s.IterateUTXOSetAtBlockFromAcceptanceData(pruningPoint,
+		func(outpoint *externalapi.DomainOutpoint, entry externalapi.UTXOEntry) error {
+			return writer.AddEntry(outpoint, entry)
+		})
+	if err != nil {
+		log.Errorf("[AUTO-EXODUS] FAILED: acceptance-data UTXO walk for pruning point %s failed: %s (partial bundle: %s)",
+			pruningPoint, err, bundleDir)
+		return
+	}
+
+	commitment, err := writer.Finalize(exodus.BundleMeta{
+		ToolVersion: version.Version(),
+		NodeVersion: version.Version(),
+		Network:     network,
+	})
+	if err != nil {
+		log.Errorf("[AUTO-EXODUS] FAILED: could not finalize bundle for pruning point %s at %s: %s",
+			pruningPoint, bundleDir, err)
+		return
+	}
+
+	headerCommitment := header.UTXOCommitment()
+	if commitment.Equal(headerCommitment) {
+		log.Infof("[AUTO-EXODUS] PASS: pruning point %s (DAA score %d) exported %d UTXOs; computed commitment %s matches header commitment %s; bundle=%s",
+			pruningPoint, daaScore, writer.EntryCount(), commitment, headerCommitment, bundleDir)
+		return
+	}
+	log.Errorf("[AUTO-EXODUS] FAIL: pruning point %s (DAA score %d) exported %d UTXOs; computed commitment %s does not match header commitment %s; bundle=%s",
+		pruningPoint, daaScore, writer.EntryCount(), commitment, headerCommitment, bundleDir)
 }
 
 // In order to prevent a situation that the consensus lock is held for too much time, we

--- a/domain/consensus/consensus.go
+++ b/domain/consensus/consensus.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"os"

--- a/domain/consensus/datastructures/pruningstore/pruning_store.go
+++ b/domain/consensus/datastructures/pruningstore/pruning_store.go
@@ -29,8 +29,8 @@ var (
 	// re-run their full multi-minute scan on every single boot when the underlying data - the
 	// current pruning point, or the root of any disqualification cascade - hasn't actually changed
 	// since the last time they ran.
-	lastUTXODebugCheckedPruningPointKeyName = []byte("last-utxo-debug-checked-pruning-point")
-	lastUTXODebugReproducedRootHashKeyName  = []byte("last-utxo-debug-reproduced-root-disqualified-block")
+	lastUTXODebugCheckedPruningPointKeyName   = []byte("last-utxo-debug-checked-pruning-point")
+	lastUTXODebugReproducedRootHashKeyName    = []byte("last-utxo-debug-reproduced-root-disqualified-block")
 	lastAutoExodusExportedPruningPointKeyName = []byte("last-auto-exodus-exported-pruning-point")
 )
 
@@ -51,8 +51,8 @@ type pruningStore struct {
 	pruningPointByIndexBucket       model.DBBucket
 	lastPruningTimeKey              model.DBKey
 
-	lastUTXODebugCheckedPruningPointKey model.DBKey
-	lastUTXODebugReproducedRootHashKey  model.DBKey
+	lastUTXODebugCheckedPruningPointKey   model.DBKey
+	lastUTXODebugReproducedRootHashKey    model.DBKey
 	lastAutoExodusExportedPruningPointKey model.DBKey
 }
 
@@ -70,8 +70,8 @@ func New(prefixBucket model.DBBucket, cacheSize int, preallocate bool) model.Pru
 		pruningPointByIndexBucket:       prefixBucket.Bucket(pruningPointByIndexBucketName),
 		lastPruningTimeKey:              prefixBucket.Key(lastPruningTimeKeyName),
 
-		lastUTXODebugCheckedPruningPointKey: prefixBucket.Key(lastUTXODebugCheckedPruningPointKeyName),
-		lastUTXODebugReproducedRootHashKey:  prefixBucket.Key(lastUTXODebugReproducedRootHashKeyName),
+		lastUTXODebugCheckedPruningPointKey:   prefixBucket.Key(lastUTXODebugCheckedPruningPointKeyName),
+		lastUTXODebugReproducedRootHashKey:    prefixBucket.Key(lastUTXODebugReproducedRootHashKeyName),
 		lastAutoExodusExportedPruningPointKey: prefixBucket.Key(lastAutoExodusExportedPruningPointKeyName),
 	}
 }
@@ -211,22 +211,6 @@ func (ps *pruningStore) PruningPointByIndex(dbContext model.DBReader, stagingAre
 		return prunintpoint, nil
 	}
 
-	func (ps *pruningStore) SetLastAutoExodusExportedPruningPoint(dbContext model.DBWriter, pruningPoint *externalapi.DomainHash) error {
-		hashBytes, err := ps.serializeHash(pruningPoint)
-		if err != nil {
-			return err
-		}
-		return dbContext.Put(ps.lastAutoExodusExportedPruningPointKey, hashBytes)
-	}
-
-	func (ps *pruningStore) LastAutoExodusExportedPruningPoint(dbContext model.DBReader) (*externalapi.DomainHash, error) {
-		hashBytes, err := dbContext.Get(ps.lastAutoExodusExportedPruningPointKey)
-		if err != nil {
-			return nil, err
-		}
-		return ps.deserializePruningPoint(hashBytes)
-	}
-
 	prunintpointCached, exists := ps.pruningPointByIndexCache.Get(index)
 	if exists && prunintpointCached != nil {
 		return prunintpointCached, nil
@@ -246,6 +230,22 @@ func (ps *pruningStore) PruningPointByIndex(dbContext model.DBReader, stagingAre
 	}
 	ps.pruningPointByIndexCache.Add(index, pruningPointDeserialized)
 	return pruningPointDeserialized, nil
+}
+
+func (ps *pruningStore) SetLastAutoExodusExportedPruningPoint(dbContext model.DBWriter, pruningPoint *externalapi.DomainHash) error {
+	hashBytes, err := ps.serializeHash(pruningPoint)
+	if err != nil {
+		return err
+	}
+	return dbContext.Put(ps.lastAutoExodusExportedPruningPointKey, hashBytes)
+}
+
+func (ps *pruningStore) LastAutoExodusExportedPruningPoint(dbContext model.DBReader) (*externalapi.DomainHash, error) {
+	hashBytes, err := dbContext.Get(ps.lastAutoExodusExportedPruningPointKey)
+	if err != nil {
+		return nil, err
+	}
+	return ps.deserializePruningPoint(hashBytes)
 }
 
 func (ps *pruningStore) serializeHash(hash *externalapi.DomainHash) ([]byte, error) {

--- a/domain/consensus/datastructures/pruningstore/pruning_store.go
+++ b/domain/consensus/datastructures/pruningstore/pruning_store.go
@@ -31,6 +31,7 @@ var (
 	// since the last time they ran.
 	lastUTXODebugCheckedPruningPointKeyName = []byte("last-utxo-debug-checked-pruning-point")
 	lastUTXODebugReproducedRootHashKeyName  = []byte("last-utxo-debug-reproduced-root-disqualified-block")
+	lastAutoExodusExportedPruningPointKeyName = []byte("last-auto-exodus-exported-pruning-point")
 )
 
 // pruningStore represents a store for the current pruning state
@@ -52,6 +53,7 @@ type pruningStore struct {
 
 	lastUTXODebugCheckedPruningPointKey model.DBKey
 	lastUTXODebugReproducedRootHashKey  model.DBKey
+	lastAutoExodusExportedPruningPointKey model.DBKey
 }
 
 // New instantiates a new PruningStore
@@ -70,6 +72,7 @@ func New(prefixBucket model.DBBucket, cacheSize int, preallocate bool) model.Pru
 
 		lastUTXODebugCheckedPruningPointKey: prefixBucket.Key(lastUTXODebugCheckedPruningPointKeyName),
 		lastUTXODebugReproducedRootHashKey:  prefixBucket.Key(lastUTXODebugReproducedRootHashKeyName),
+		lastAutoExodusExportedPruningPointKey: prefixBucket.Key(lastAutoExodusExportedPruningPointKeyName),
 	}
 }
 
@@ -206,6 +209,22 @@ func (ps *pruningStore) PruningPointByIndex(dbContext model.DBReader, stagingAre
 	prunintpoint, exists := stagingShard.pruningPointByIndex[index]
 	if exists && prunintpoint != nil {
 		return prunintpoint, nil
+	}
+
+	func (ps *pruningStore) SetLastAutoExodusExportedPruningPoint(dbContext model.DBWriter, pruningPoint *externalapi.DomainHash) error {
+		hashBytes, err := ps.serializeHash(pruningPoint)
+		if err != nil {
+			return err
+		}
+		return dbContext.Put(ps.lastAutoExodusExportedPruningPointKey, hashBytes)
+	}
+
+	func (ps *pruningStore) LastAutoExodusExportedPruningPoint(dbContext model.DBReader) (*externalapi.DomainHash, error) {
+		hashBytes, err := dbContext.Get(ps.lastAutoExodusExportedPruningPointKey)
+		if err != nil {
+			return nil, err
+		}
+		return ps.deserializePruningPoint(hashBytes)
 	}
 
 	prunintpointCached, exists := ps.pruningPointByIndexCache.Get(index)

--- a/domain/consensus/factory.go
+++ b/domain/consensus/factory.go
@@ -81,6 +81,10 @@ type Config struct {
 	// 15-20+ minutes on a mature chain. Off by default; only for actively investigating a UTXO
 	// commitment mismatch.
 	EnableUTXODebugDiagnostics bool
+	// EnableAutoExodusExportOnPruning exports an acceptance-data Exodus bundle after a pruning point moves.
+	// AutoExodusExportDir is the parent directory for those best-effort diagnostic bundles.
+	EnableAutoExodusExportOnPruning bool
+	AutoExodusExportDir             string
 
 	SkipAddingGenesis bool
 
@@ -355,6 +359,14 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 		return nil, false, err
 	}
 
+	var c *consensus
+	var autoExodusExport func(*externalapi.DomainHash)
+	if config.EnableAutoExodusExportOnPruning {
+		autoExodusExport = func(pruningPoint *externalapi.DomainHash) {
+			go c.exportPruningPointExodusBundle(pruningPoint, config.AutoExodusExportDir, config.Name)
+		}
+	}
+
 	pruningManager := pruningmanager.New(
 		dbManager,
 		dagTraversalManager,
@@ -384,6 +396,7 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 		config.DataRetentionDuration,
 		config.PruningInterval,
 		config.EnableSanityCheckPruningUTXOSet,
+		autoExodusExport,
 		config.K,
 		config.DifficultyAdjustmentWindowSize,
 		config.TargetTimePerBlock,
@@ -539,7 +552,7 @@ func (f *factory) NewConsensus(config *Config, db infrastructuredatabase.Databas
 		config.MaxBlockLevel,
 	)
 
-	c := &consensus{
+	c = &consensus{
 		lock:            &sync.Mutex{},
 		databaseContext: dbManager,
 		genesisBlock:    config.GenesisBlock,

--- a/domain/consensus/model/interface_datastructures_pruningstore.go
+++ b/domain/consensus/model/interface_datastructures_pruningstore.go
@@ -47,6 +47,8 @@ type PruningStore interface {
 	LastUTXODebugCheckedPruningPoint(dbContext DBReader) (*externalapi.DomainHash, error)
 	SetLastUTXODebugReproducedRootHash(dbContext DBWriter, rootHash *externalapi.DomainHash) error
 	LastUTXODebugReproducedRootHash(dbContext DBReader) (*externalapi.DomainHash, error)
+	SetLastAutoExodusExportedPruningPoint(dbContext DBWriter, pruningPoint *externalapi.DomainHash) error
+	LastAutoExodusExportedPruningPoint(dbContext DBReader) (*externalapi.DomainHash, error)
 
 	CacheLen() int
 	UnstageAll(stagingArea *StagingArea)

--- a/domain/consensus/processes/pruningmanager/pruningmanager.go
+++ b/domain/consensus/processes/pruningmanager/pruningmanager.go
@@ -50,6 +50,7 @@ type pruningManager struct {
 	dataRetentionDuration           time.Duration
 	pruningInterval                 time.Duration
 	shouldSanityCheckPruningUTXOSet bool
+	autoExodusExport                func(*externalapi.DomainHash)
 	k                               []externalapi.KType
 	difficultyAdjustmentWindowSize  []int
 
@@ -91,6 +92,7 @@ func New(
 	dataRetentionDuration time.Duration,
 	pruningInterval time.Duration,
 	shouldSanityCheckPruningUTXOSet bool,
+	autoExodusExport func(*externalapi.DomainHash),
 	k []externalapi.KType,
 	difficultyAdjustmentWindowSize []int,
 	targetTimePerBlock []time.Duration,
@@ -124,6 +126,7 @@ func New(
 		pruningInterval:                 pruningInterval,
 		finalityInterval:                finalityInterval,
 		shouldSanityCheckPruningUTXOSet: shouldSanityCheckPruningUTXOSet,
+		autoExodusExport:                autoExodusExport,
 		k:                               k,
 		difficultyAdjustmentWindowSize:  difficultyAdjustmentWindowSize,
 		targetTimePerBlock:              targetTimePerBlock,
@@ -2118,7 +2121,28 @@ func (pm *pruningManager) updatePruningPoint() error {
 	pm.cachedPruningPointAnticone = nil
 
 	log.Info("Finishing updating the pruning point UTXO set")
-	return pm.pruningStore.FinishUpdatingPruningPointUTXOSet(pm.databaseContext)
+	err = pm.pruningStore.FinishUpdatingPruningPointUTXOSet(pm.databaseContext)
+	if err != nil {
+		return err
+	}
+	pm.triggerAutoExodusExport(pruningPoint)
+	return nil
+}
+
+func (pm *pruningManager) triggerAutoExodusExport(pruningPoint *externalapi.DomainHash) {
+	if pm.autoExodusExport == nil || pruningPoint.Equal(pm.genesisHash) {
+		return
+	}
+	if lastExported, err := pm.pruningStore.LastAutoExodusExportedPruningPoint(pm.databaseContext); err == nil && lastExported.Equal(pruningPoint) {
+		log.Infof("[AUTO-EXODUS] pruning point %s was already exported; skipping", pruningPoint)
+		return
+	}
+	if err := pm.pruningStore.SetLastAutoExodusExportedPruningPoint(pm.databaseContext, pruningPoint); err != nil {
+		log.Errorf("[AUTO-EXODUS] could not persist export marker for pruning point %s: %s; skipping export to prevent duplicates", pruningPoint, err)
+		return
+	}
+	log.Infof("[AUTO-EXODUS] scheduling acceptance-data Exodus export for pruning point %s", pruningPoint)
+	pm.autoExodusExport(pruningPoint)
 }
 
 func (pm *pruningManager) PruneAllBlocksBelow(stagingArea *model.StagingArea, pruningPointHash *externalapi.DomainHash) error {

--- a/infrastructure/config/config.go
+++ b/infrastructure/config/config.go
@@ -161,6 +161,8 @@ type Flags struct {
 	AllowSubmitBlockWhenNotSynced   bool          `long:"allow-submit-block-when-not-synced" hidden:"true" description:"Allow the node to accept blocks from RPC while not synced (this flag is mainly used for testing)"`
 	EnableSanityCheckPruningUTXOSet bool          `long:"enable-sanity-check-pruning-utxo" hidden:"true" description:"When moving the pruning point - check that the utxo set matches the utxo commitment"`
 	EnableUTXODebugDiagnostics      bool          `long:"enable-utxo-debug-diagnostics" hidden:"true" description:"At startup, run the expensive [UTXO-DEBUG] pruning-point/virtual-UTXO-set self-consistency checks and root-disqualification bisection (each pass can take 15-20+ minutes on a mature chain). Off by default - only for actively investigating a UTXO commitment mismatch."`
+	EnableAutoExodusExportOnPruning bool          `long:"enable-auto-exodus-export-on-pruning" hidden:"true" description:"After each pruning point movement, asynchronously export an acceptance-data Exodus bundle and log its header commitment comparison. Off by default."`
+	AutoExodusExportDir             string        `long:"auto-exodus-export-dir" hidden:"true" description:"Directory for automatic Exodus exports (default: <appdir>/exodus-auto-export)"`
 	ProtocolVersion                 uint32        `long:"protocol-version" hidden:"true" description:"Use non default p2p protocol version"`
 
 	// Compound transaction rate limiting flags
@@ -426,6 +428,10 @@ func LoadConfig() (*Config, error) {
 	// means each individual piece of serialized data does not have to
 	// worry about changing names per network and such.
 	cfg.AppDir = filepath.Join(cfg.AppDir, cfg.NetParams().Name)
+	if cfg.AutoExodusExportDir == "" {
+		cfg.AutoExodusExportDir = filepath.Join(cfg.AppDir, "exodus-auto-export")
+	}
+	cfg.AutoExodusExportDir = cleanAndExpandPath(cfg.AutoExodusExportDir)
 
 	// Logs directory is usually under the home directory, unless otherwise specified
 	if cfg.LogDir == "" {


### PR DESCRIPTION
Merge auto-enable pruning point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional automatic Exodus bundle exports when the pruning point advances.
  - Exports include UTXO data and metadata, with commitment validation and success or failure logging.
  - Added configurable export locations, including a network-specific default directory.
  - Export processing is asynchronous and best effort, so it does not affect consensus or pruning success.

- **Documentation**
  - Documented automatic Exodus export configuration, output naming, logging, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->